### PR TITLE
CORE-8487 Refactor metadata-client as a protocol implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# metadata-client
+
+A client library for the CyVerse Discovery Environment metadata service.
+
+## Usage
+
+```clojure
+(require '[metadata-client.core :as mcc])
+
+(def client (mcc/new-metadata-client base-uri))
+
+;; Metadata AVU operations.
+(mcc/list-avus client username target-type target-id)
+(mcc/update-avus client username target-type target-id request-body)
+(mcc/set-avus client username target-type target-id request-body)
+(mcc/copy-metadata-avus client username target-type target-id dest-targets)
+(mcc/filter-by-avus client username target-types target-ids avus)
+
+;; Ontology operations.
+(mcc/list-ontologies client username)
+(mcc/list-hierarchies client username ontology-version)
+(mcc/filter-hierarchies client username ontology-version attrs target-type target-id)
+(mcc/filter-targets-by-ontology-search client username ontology-version attrs search-term target-types target-ids)
+(mcc/filter-hierarchy client username ontology-version root-iri attr target-types target-ids)
+(mcc/filter-hierarchy-targets client username ontology-version root-iri attr target-types target-ids)
+(mcc/filter-unclassified client username ontology-version root-iri attr target-types target-ids)
+(mcc/delete-ontology client username ontology-version)
+```
+
+## License
+
+http://www.cyverse.org/sites/default/files/iPLANT-LICENSE.txt

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/metadata-client "2.8.2-SNAPSHOT"
+(defproject org.cyverse/metadata-client "3.0.0-SNAPSHOT"
   :description "Client for the metadata service"
   :url "https://github.com/cyverse-de/metadata-client"
   :license {:name "BSD"

--- a/src/metadata_client/core.clj
+++ b/src/metadata_client/core.clj
@@ -5,21 +5,75 @@
             [clj-http.client :as http]
             [clojure.tools.logging :as log]))
 
-(def ^:dynamic *metadata-base*
-  "Dynamic context to be used in generating URLs."
-  "http://localhost:60000")
+(defprotocol Client
+  "A client library for the Metadata API."
 
-(defmacro with-metadata-base
-  "A helper macro to change *metadata-base* within its body."
-  [metadata-base & body]
-  `(let [metadata-base# ~metadata-base]
-     (binding [*metadata-base* metadata-base#]
-       ~@body)))
+  (delete-ontology
+    [_ username ontology-version]
+    "Marks an Ontology as deleted in the database.")
+
+  (list-ontologies
+    [_ username]
+    "List Ontology Details")
+
+  (list-hierarchies
+    [_ username ontology-version]
+    "List Ontology Hierarchies saved for the given `ontology-version`.")
+
+  (filter-hierarchies
+    [_ username ontology-version attrs target-type target-id]
+    "Filters Ontology Hierarchies saved for the given `ontology-version`,
+     returning only the hierarchy's leaf-classes that are associated with the given target.")
+
+  (filter-targets-by-ontology-search
+    [_ username ontology-version attrs search-term target-types target-ids]
+    "Filters the given target IDs by returning only those that have any of the given `attrs`
+     and Ontology class IRIs as values whose labels match the given Ontology class `label`.")
+
+  (filter-hierarchy
+    [_ username ontology-version root-iri attr target-types target-ids]
+    "Filters an Ontology Hierarchy, rooted at the given `root-iri`, returning only the
+     hierarchy's leaf-classes that are associated with the given targets.")
+
+  (filter-by-avus
+    [_ username target-types target-ids avus]
+    "Filters the given target IDs by returning a list of any that have metadata with the given
+     `attrs` and `values`.")
+
+  (filter-hierarchy-targets
+    [_ username ontology-version root-iri attr target-types target-ids]
+    "Filters the given target IDs by returning only those that are associated with any Ontology
+     classes of the hierarchy rooted at the given `root-iri`.")
+
+  (filter-unclassified
+    [_ username ontology-version root-iri attr target-types target-ids]
+    "Filters the given target IDs by returning a list of any that are not associated with any
+     Ontology classes of the hierarchy rooted at the given `root-iri`.")
+
+  (list-avus
+    [_ username target-type target-id]
+    [_ username target-type target-id opts]
+    "Lists all AVUs associated with the target item.")
+
+  (set-avus
+    [_ username target-type target-id body]
+    "Sets Metadata AVUs on the given target item.
+     Any AVUs not included in the request will be deleted. If the AVUs are omitted, then all AVUs for the
+     given target ID will be deleted.")
+
+  (update-avus
+    [_ username target-type target-id body]
+    "Adds or updates Metadata AVUs on the given target item.")
+
+  (copy-metadata-avus
+    [_ username target-type target-id dest-items]
+    "Copies all Metadata Template AVUs from the data item with the ID given in the URL to other data
+     items sent in the request body."))
 
 (defn- metadata-url-encoded
-  [& components]
-  (log/debug "using metadata base" *metadata-base*)
-  (str (apply curl/url *metadata-base* (map curl/url-encode components))))
+  [base-url & components]
+  (log/debug "using metadata base URL" base-url)
+  (str (apply curl/url base-url (map curl/url-encode components))))
 
 (defn- get-options
   [params & {:keys [as] :or {as :stream}}]
@@ -38,96 +92,107 @@
 (def ^:private delete-options get-options)
 (def ^:private put-options post-options)
 
-(defn delete-ontology
-  [username ontology-version]
-  (http/delete (metadata-url-encoded "admin" "ontologies" ontology-version)
-               (delete-options {:user username})))
+(deftype MetadataClient [base-url]
+  Client
 
-(defn list-ontologies
-  [username]
-  (-> (http/get (metadata-url-encoded "ontologies")
-                (get-options {:user username} :as :json))
-      :body))
+  (delete-ontology
+    [_ username ontology-version]
+    (http/delete (metadata-url-encoded base-url "admin" "ontologies" ontology-version)
+                 (delete-options {:user username})))
 
-(defn list-hierarchies
-  [username ontology-version]
-  (http/get (metadata-url-encoded "ontologies" ontology-version)
-            (get-options {:user username})))
+  (list-ontologies
+    [_ username]
+    (-> (http/get (metadata-url-encoded base-url "ontologies")
+                  (get-options {:user username} :as :json))
+        :body))
 
-(defn filter-hierarchies
-  [username ontology-version attrs target-type target-id]
-  (->> (http/post (metadata-url-encoded "ontologies" ontology-version "filter")
-                  (post-options (json/encode {:attrs attrs :type target-type :id target-id})
-                                {:user username}
-                                :as :json))
-       :body))
+  (list-hierarchies
+    [_ username ontology-version]
+    (http/get (metadata-url-encoded base-url "ontologies" ontology-version)
+              (get-options {:user username})))
 
-(defn filter-targets-by-ontology-search
-  [username ontology-version attrs search-term target-types target-ids]
-  (->> (http/post (metadata-url-encoded "ontologies" ontology-version "filter-targets")
-                  (post-options (json/encode {:attrs        attrs
-                                              :target-types target-types
-                                              :target-ids   target-ids})
-                                {:user username :label search-term}
-                                :as :json))
-       :body
-       :target-ids
-       (map uuidify)))
+  (filter-hierarchies
+    [_ username ontology-version attrs target-type target-id]
+    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version "filter")
+                    (post-options (json/encode {:attrs attrs :type target-type :id target-id})
+                                  {:user username}
+                                  :as :json))
+         :body))
 
-(defn filter-hierarchy
-  [username ontology-version root-iri attr target-types target-ids]
-  (http/post (metadata-url-encoded "ontologies" ontology-version root-iri "filter")
-             (post-options (json/encode {:target-types target-types :target-ids target-ids})
-                           {:user username :attr attr})))
+  (filter-targets-by-ontology-search
+    [_ username ontology-version attrs search-term target-types target-ids]
+    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version "filter-targets")
+                    (post-options (json/encode {:attrs        attrs
+                                                :target-types target-types
+                                                :target-ids   target-ids})
+                                  {:user username :label search-term}
+                                  :as :json))
+         :body
+         :target-ids
+         (map uuidify)))
 
-(defn filter-by-avus
-  [username target-types target-ids avus]
-  (->> (http/post (metadata-url-encoded "avus" "filter-targets")
-                  (post-options (json/encode {:target-types target-types
-                                              :target-ids   target-ids
-                                              :avus         avus})
-                                {:user username}
-                                :as :json))
-       :body
-       :target-ids
-       (map uuidify)))
+  (filter-hierarchy
+    [_ username ontology-version root-iri attr target-types target-ids]
+    (http/post (metadata-url-encoded base-url "ontologies" ontology-version root-iri "filter")
+               (post-options (json/encode {:target-types target-types :target-ids target-ids})
+                             {:user username :attr attr})))
 
-(defn filter-hierarchy-targets
-  [username ontology-version root-iri attr target-types target-ids]
-  (->> (http/post (metadata-url-encoded "ontologies" ontology-version root-iri "filter-targets")
-                  (post-options (json/encode {:target-types target-types :target-ids target-ids})
-                                {:user username :attr attr}
-                                :as :json))
-       :body
-       :target-ids
-       (map uuidify)))
+  (filter-by-avus
+    [_ username target-types target-ids avus]
+    (->> (http/post (metadata-url-encoded base-url "avus" "filter-targets")
+                    (post-options (json/encode {:target-types target-types
+                                                :target-ids   target-ids
+                                                :avus         avus})
+                                  {:user username}
+                                  :as :json))
+         :body
+         :target-ids
+         (map uuidify)))
 
-(defn filter-unclassified
-  [username ontology-version root-iri attr target-types target-ids]
-  (->> (http/post (metadata-url-encoded "ontologies" ontology-version root-iri "filter-unclassified")
-                  (post-options (json/encode {:target-types target-types :target-ids target-ids})
-                                {:user username :attr attr}
-                                :as :json))
-       :body
-       :target-ids
-       (map uuidify)))
+  (filter-hierarchy-targets
+    [_ username ontology-version root-iri attr target-types target-ids]
+    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version root-iri "filter-targets")
+                    (post-options (json/encode {:target-types target-types :target-ids target-ids})
+                                  {:user username :attr attr}
+                                  :as :json))
+         :body
+         :target-ids
+         (map uuidify)))
 
-(defn list-avus
-  [username target-type target-id & {:keys [as] :or {as :stream}}]
-  (http/get (metadata-url-encoded "avus" target-type target-id)
-            (get-options {:user username} :as as)))
+  (filter-unclassified
+    [_ username ontology-version root-iri attr target-types target-ids]
+    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version root-iri "filter-unclassified")
+                    (post-options (json/encode {:target-types target-types :target-ids target-ids})
+                                  {:user username :attr attr}
+                                  :as :json))
+         :body
+         :target-ids
+         (map uuidify)))
 
-(defn set-avus
-  [username target-type target-id body]
-  (http/put (metadata-url-encoded "avus" target-type target-id)
-            (put-options body {:user username})))
+  (list-avus
+    [_ username target-type target-id]
+    (http/get (metadata-url-encoded base-url "avus" target-type target-id)
+              (get-options {:user username})))
 
-(defn update-avus
-  [username target-type target-id body]
-  (http/post (metadata-url-encoded "avus" target-type target-id)
-             (post-options body {:user username})))
+  (list-avus
+    [_ username target-type target-id {:keys [as] :or {as :stream}}]
+    (http/get (metadata-url-encoded base-url "avus" target-type target-id)
+              (get-options {:user username} :as as)))
 
-(defn copy-metadata-avus
-  [username target-type target-id dest-items]
-  (http/post (metadata-url-encoded "avus" target-type target-id "copy")
-             (post-options (json/encode {:targets dest-items}) {:user username})))
+  (set-avus
+    [_ username target-type target-id body]
+    (http/put (metadata-url-encoded base-url "avus" target-type target-id)
+              (put-options body {:user username})))
+
+  (update-avus
+    [_ username target-type target-id body]
+    (http/post (metadata-url-encoded base-url "avus" target-type target-id)
+               (post-options body {:user username})))
+
+  (copy-metadata-avus
+    [_ username target-type target-id dest-items]
+    (http/post (metadata-url-encoded base-url "avus" target-type target-id "copy")
+               (post-options (json/encode {:targets dest-items}) {:user username}))))
+
+(defn new-metadata-client [base-url]
+  (MetadataClient. base-url))

--- a/src/metadata_client/core.clj
+++ b/src/metadata_client/core.clj
@@ -70,7 +70,7 @@
     "Copies all Metadata Template AVUs from the data item with the ID given in the URL to other data
      items sent in the request body."))
 
-(defn- metadata-url-encoded
+(defn- metadata-url
   [base-url & components]
   (log/debug "using metadata base URL" base-url)
   (str (apply curl/url base-url (map curl/url-encode components))))
@@ -97,23 +97,23 @@
 
   (delete-ontology
     [_ username ontology-version]
-    (http/delete (metadata-url-encoded base-url "admin" "ontologies" ontology-version)
+    (http/delete (metadata-url base-url "admin" "ontologies" ontology-version)
                  (delete-options {:user username})))
 
   (list-ontologies
     [_ username]
-    (-> (http/get (metadata-url-encoded base-url "ontologies")
+    (-> (http/get (metadata-url base-url "ontologies")
                   (get-options {:user username} :as :json))
         :body))
 
   (list-hierarchies
     [_ username ontology-version]
-    (http/get (metadata-url-encoded base-url "ontologies" ontology-version)
+    (http/get (metadata-url base-url "ontologies" ontology-version)
               (get-options {:user username})))
 
   (filter-hierarchies
     [_ username ontology-version attrs target-type target-id]
-    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version "filter")
+    (->> (http/post (metadata-url base-url "ontologies" ontology-version "filter")
                     (post-options (json/encode {:attrs attrs :type target-type :id target-id})
                                   {:user username}
                                   :as :json))
@@ -121,7 +121,7 @@
 
   (filter-targets-by-ontology-search
     [_ username ontology-version attrs search-term target-types target-ids]
-    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version "filter-targets")
+    (->> (http/post (metadata-url base-url "ontologies" ontology-version "filter-targets")
                     (post-options (json/encode {:attrs        attrs
                                                 :target-types target-types
                                                 :target-ids   target-ids})
@@ -133,13 +133,13 @@
 
   (filter-hierarchy
     [_ username ontology-version root-iri attr target-types target-ids]
-    (http/post (metadata-url-encoded base-url "ontologies" ontology-version root-iri "filter")
+    (http/post (metadata-url base-url "ontologies" ontology-version root-iri "filter")
                (post-options (json/encode {:target-types target-types :target-ids target-ids})
                              {:user username :attr attr})))
 
   (filter-by-avus
     [_ username target-types target-ids avus]
-    (->> (http/post (metadata-url-encoded base-url "avus" "filter-targets")
+    (->> (http/post (metadata-url base-url "avus" "filter-targets")
                     (post-options (json/encode {:target-types target-types
                                                 :target-ids   target-ids
                                                 :avus         avus})
@@ -151,7 +151,7 @@
 
   (filter-hierarchy-targets
     [_ username ontology-version root-iri attr target-types target-ids]
-    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version root-iri "filter-targets")
+    (->> (http/post (metadata-url base-url "ontologies" ontology-version root-iri "filter-targets")
                     (post-options (json/encode {:target-types target-types :target-ids target-ids})
                                   {:user username :attr attr}
                                   :as :json))
@@ -161,7 +161,7 @@
 
   (filter-unclassified
     [_ username ontology-version root-iri attr target-types target-ids]
-    (->> (http/post (metadata-url-encoded base-url "ontologies" ontology-version root-iri "filter-unclassified")
+    (->> (http/post (metadata-url base-url "ontologies" ontology-version root-iri "filter-unclassified")
                     (post-options (json/encode {:target-types target-types :target-ids target-ids})
                                   {:user username :attr attr}
                                   :as :json))
@@ -171,27 +171,27 @@
 
   (list-avus
     [_ username target-type target-id]
-    (http/get (metadata-url-encoded base-url "avus" target-type target-id)
+    (http/get (metadata-url base-url "avus" target-type target-id)
               (get-options {:user username})))
 
   (list-avus
     [_ username target-type target-id {:keys [as] :or {as :stream}}]
-    (http/get (metadata-url-encoded base-url "avus" target-type target-id)
+    (http/get (metadata-url base-url "avus" target-type target-id)
               (get-options {:user username} :as as)))
 
   (set-avus
     [_ username target-type target-id body]
-    (http/put (metadata-url-encoded base-url "avus" target-type target-id)
+    (http/put (metadata-url base-url "avus" target-type target-id)
               (put-options body {:user username})))
 
   (update-avus
     [_ username target-type target-id body]
-    (http/post (metadata-url-encoded base-url "avus" target-type target-id)
+    (http/post (metadata-url base-url "avus" target-type target-id)
                (post-options body {:user username})))
 
   (copy-metadata-avus
     [_ username target-type target-id dest-items]
-    (http/post (metadata-url-encoded base-url "avus" target-type target-id "copy")
+    (http/post (metadata-url base-url "avus" target-type target-id "copy")
                (post-options (json/encode {:targets dest-items}) {:user username}))))
 
 (defn new-metadata-client [base-url]

--- a/src/metadata_client/middleware.clj
+++ b/src/metadata_client/middleware.clj
@@ -1,7 +1,0 @@
-(ns metadata-client.middleware
-  (:use [metadata-client.core :only [with-metadata-base]]))
-
-(defn wrap-metadata-base-url
-  [handler base-url-fn]
-  (fn [request]
-    (with-metadata-base (base-url-fn) (handler request))))


### PR DESCRIPTION
This PR refactors the `metadata-client` library as a protocol implementation, so that `metadata-client.middleware/wrap-metadata-base-url` and the `with-metadata-base` macro are no longer required.