### PR TITLE
CORE-11 Update some methods to return JSON response maps.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/metadata-client "3.0.2-SNAPSHOT"
+(defproject org.cyverse/metadata-client "3.1.0-SNAPSHOT"
   :description "Client for the metadata service"
   :url "https://github.com/cyverse-de/metadata-client"
   :license {:name "BSD"


### PR DESCRIPTION
This PR will:

* Update `filter-hierarchy` to return a JSON response body.
* Add a `list-hierarchies` method that accepts an {:as :json} GET option.
* DRY refactor so that one `list-avus` method calls the other.
* Bump the version to `3.1.0-SNAPSHOT` since the `filter-hierarchy` change is breaking (but only the apps service is using that method currently).