### PR TITLE
CORE-2034 Search AVUs by `target-ids`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/metadata-client "3.1.3-SNAPSHOT"
+(defproject org.cyverse/metadata-client "3.2.0-SNAPSHOT"
   :description "Client for the metadata service"
   :url "https://github.com/cyverse-de/metadata-client"
   :license {:name "BSD"

--- a/src/metadata_client/core.clj
+++ b/src/metadata_client/core.clj
@@ -11,8 +11,9 @@
 
   (find-avus
     [_ username criteria]
-    "Searches for AVUs that match the given search criteria. Available criteria are `:attribute`, `:target-type`
-     `:value`, and `:unit`. Each criterion can be either an acceptable match or a list of acceptable matches.")
+    "Searches for AVUs that match the given search criteria.
+     Available criteria are `:attribute`, `:target-type`, `:target-id`, `:value`, and `:unit`.
+     Each criterion can be either an acceptable match or a list of acceptable matches.")
 
   (delete-avus
     [_ username target-types target-ids avus]
@@ -110,7 +111,7 @@
 
   (find-avus
     [_ username params]
-    (let [params (remove-vals nil? (select-keys params [:attribute :target-type :value :unit]))]
+    (let [params (remove-vals nil? (select-keys params [:attribute :target-type :target-id :value :unit]))]
       (:body (http/get (metadata-url base-url "avus")
                        (get-options (assoc params :user username)
                                     :as :json)))))

--- a/src/metadata_client/core.clj
+++ b/src/metadata_client/core.clj
@@ -15,6 +15,12 @@
      Available criteria are `:attribute`, `:target-type`, `:target-id`, `:value`, and `:unit`.
      Each criterion can be either an acceptable match or a list of acceptable matches.")
 
+  (search-avus
+    [_ username criteria]
+    "Searches for AVUs that match the given search criteria.
+     Available criteria are `:attribute`, `:target-type`, `:target-id`, `:value`, and `:unit`.
+     Each criterion must be a list of acceptable matches.")
+
   (delete-avus
     [_ username target-types target-ids avus]
     "Deletes AVUs matching those in the given `avus` list from the given `target-ids`.")
@@ -115,6 +121,14 @@
       (:body (http/get (metadata-url base-url "avus")
                        (get-options (assoc params :user username)
                                     :as :json)))))
+
+  (search-avus
+    [_ username params]
+    (let [body (remove-vals nil? (select-keys params [:attribute :target-type :target-id :value :unit]))]
+      (:body (http/post (metadata-url base-url "avus" "search")
+                        (post-options (json/encode body)
+                                      {:user username}
+                                      :as :json)))))
 
   (delete-avus
     [_ username target-types target-ids avus]


### PR DESCRIPTION
This PR will update the `find-avus` method to allow a list of `target-ids` to be passed through the params to the metadata service, and adds a `search-avus` method to call the new `POST /avus/search` endpoint.

This depends on cyverse-de/metadata#28 which should be merged first.